### PR TITLE
Add paths for the EU Funding Registration form

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -19,3 +19,43 @@
   :base_path: '/get-ready-brexit-check/email-signup'
   :title: 'Email signup: what you need to do to prepare for Brexit'
   :rendering_app: 'finder-frontend'
+
+- :content_id: 'fe29ccb9-99c5-4727-a64e-57aa4a44ab81'
+  :base_path: '/brexit-eu-funding/who-should-we-contact-about-the-grant-award'
+  :title: 'Register as an organisation which gets funding directly from the EU'
+  :rendering_app: 'frontend'
+
+- :content_id: '7028ad9f-1a3e-4921-b0f1-d7085c7daa1b'
+  :base_path: '/brexit-eu-funding/organisation-type'
+  :title: 'Register as an organisation which gets funding directly from the EU'
+  :rendering_app: 'frontend'
+
+- :content_id: '9d76509b-7a8d-42e0-aa1a-300616dbbed8'
+  :base_path: '/brexit-eu-funding/organisation-details'
+  :title: 'Register as an organisation which gets funding directly from the EU'
+  :rendering_app: 'frontend'
+
+- :content_id: 'c422b6e0-4f0c-460b-9452-6519eefbef26'
+  :base_path: '/brexit-eu-funding/what-is-the-grant-agreement-number'
+  :title: 'Register as an organisation which gets funding directly from the EU'
+  :rendering_app: 'frontend'
+
+- :content_id: '48b4c601-7c64-4c42-a8db-8b769b51a8fd'
+  :base_path: '/brexit-eu-funding/what-programme-do-you-receive-funding-from'
+  :title: 'Register as an organisation which gets funding directly from the EU'
+  :rendering_app: 'frontend'
+
+- :content_id: '72969d5e-832f-4e16-b9cb-0c9ab0fad3e4'
+  :base_path: '/brexit-eu-funding/project-details'
+  :title: 'Register as an organisation which gets funding directly from the EU'
+  :rendering_app: 'frontend'
+
+- :content_id: 'dbd71f0f-1014-423e-b786-10ec53cd6845'
+  :base_path: '/brexit-eu-funding/check-your-answers'
+  :title: 'Register as an organisation which gets funding directly from the EU'
+  :rendering_app: 'frontend'
+
+- :content_id: '08d52d2b-3b89-4c2c-871c-7b8b2f1c92f1'
+  :base_path: '/brexit-eu-funding/confirmation'
+  :title: 'Register as an organisation which gets funding directly from the EU'
+  :rendering_app: 'frontend'


### PR DESCRIPTION
These pages are rendered by frontend, but are not a content item.  The start page `/register-eu-funding-form` will be published as a standard piece of content.

Trello card: https://trello.com/c/u3JRDIwn