### PR TITLE
Use `rubocop-govuk` instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 AllCops:
-  TargetRubyVersion: 2.5
   Exclude:
     - Rakefile

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gem "plek", "~> 3.0"
 gem "rake", "~> 13.0"
 
 group :development, :test do
-  gem "govuk-lint", "~> 4.3"
   gem "pry-byebug"
   gem "rspec", "~> 3.9"
+  gem "rubocop-govuk"
   gem "webmock", "~> 3.8"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.11.2)
     gds-api-adapters (63.5.1)
       addressable
       link_header
@@ -19,11 +18,6 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     hashdiff (1.0.0)
     http-accept (1.7.0)
     http-cookie (1.0.3)
@@ -36,8 +30,8 @@ GEM
     mime-types-data (3.2019.1009)
     netrc (0.11.0)
     null_logger (0.0.1)
-    parallel (1.18.0)
-    parser (2.6.5.0)
+    parallel (1.19.1)
+    parser (2.7.0.3)
       ast (~> 2.4.0)
     plek (3.0.0)
     pry (0.12.2)
@@ -52,9 +46,6 @@ GEM
       rack (>= 0.4)
     rainbow (3.0.0)
     rake (13.0.1)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -73,31 +64,28 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.76.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.3.2)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     webmock (3.8.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -108,12 +96,12 @@ PLATFORMS
 
 DEPENDENCIES
   gds-api-adapters (~> 63)
-  govuk-lint (~> 4.3)
   plek (~> 3.0)
   pry-byebug
   rake (~> 13.0)
   rspec (~> 3.9)
+  rubocop-govuk
   webmock (~> 3.8)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/Rakefile
+++ b/Rakefile
@@ -6,14 +6,9 @@ begin
 rescue LoadError
 end
 
-desc 'Run govuk-lint with similar params to CI'
-task :lint do
-  sh "bundle exec govuk-lint-ruby --format clang lib spec"
-end
-
 desc 'Publish special routes to the Publishing API'
 task :publish_special_routes do
   SpecialRoutePublisher.publish_special_routes
 end
 
-task default: [:spec, :lint]
+task default: [:spec]


### PR DESCRIPTION
- I'm doing this as part of the GOV.UK Developer Tooling group: https://trello.com/c/pR7GEFfU/128-make-all-current-govuk-repos-use-rubocop-govuk-instead-of-govuk-lint.
- The commit messages have more info.