### PR TITLE
Add a route for /government/uploads

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -69,3 +69,10 @@
   :base_path: '/brexit-eu-funding/confirmation'
   :title: 'Register as an organisation which gets funding directly from the EU'
   :rendering_app: 'frontend'
+
+- :content_id: '5a0ca87e-0e91-4d4c-bd26-29feb24f98ab'
+  :base_path: '/government/uploads'
+  :title: 'Government Uploads'
+  :description: 'Handles government uploads paths.'
+  :type: 'prefix'
+  :rendering_app: 'government-frontend'


### PR DESCRIPTION
Since https://github.com/alphagov/government-frontend/pull/1677 we handle this in government-frontend rather than whitehall.

[Trello Card](https://trello.com/c/Ubk3IEYg/1450-investigate-redirecting-whitehall-assets-higher-in-the-stack)