### PR TITLE
Add task to publish Coronavirus page

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,14 @@ task :publish_special_routes do
   SpecialRoutePublisher.publish_special_routes
 end
 
+desc 'Publish coronavirus routes to the Publishing API with a major update'
+task :publish_coronavirus_routes do
+  SpecialRoutePublisher.publish_coronavirus_routes
+end
+
+desc 'Publish coronavirus routes to the Publishing API with a minor update'
+task :minor_publish_coronavirus_routes do
+  SpecialRoutePublisher.minor_update_coronavirus_routes
+end
+
 task default: [:spec]

--- a/data/coronavirus_routes.yaml
+++ b/data/coronavirus_routes.yaml
@@ -1,0 +1,6 @@
+- :content_id: '774cee22-d896-44c1-a611-e3109cce8eae'
+  :base_path: '/coronavirus'
+  :title: 'Coronavirus (COVID-19): what you need to do'
+  :description: 'Find out about the government response to coronavirus (COVID-19) and what you need to do.'
+  :type: 'exact'
+  :rendering_app: 'collections'

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -4,8 +4,16 @@ require "yaml"
 
 class SpecialRoutePublisher
   def self.publish_special_routes
-    special_routes = load_special_routes
-    new.publish_routes(special_routes)
+    new.publish_routes(load_special_routes)
+  end
+
+  def self.publish_coronavirus_routes
+    new.publish_routes(load_coronavirus_routes)
+  end
+
+  def self.minor_update_coronavirus_routes
+    minor_update_routes = load_coronavirus_routes.map { |route| route.merge(update_type: "minor") }
+    new.publish_routes(minor_update_routes)
   end
 
   def publish_routes(routes)
@@ -31,8 +39,8 @@ class SpecialRoutePublisher
         publishing_api.put_content(
           route.fetch(:content_id),
           base_path: route.fetch(:base_path),
-          document_type: "special_route",
-          schema_name: "special_route",
+          document_type: route.fetch(:document_type, "special_route"),
+          schema_name: route.fetch(:document_type, "special_route"),
           title: route.fetch(:title),
           description: route.fetch(:description, ""),
           locale: "en",
@@ -60,7 +68,10 @@ class SpecialRoutePublisher
   def self.load_special_routes
     YAML.load_file("./data/special_routes.yaml")
   end
-  private_class_method :load_special_routes
+
+  def self.load_coronavirus_routes
+    YAML.load_file("./data/coronavirus_routes.yaml")
+  end
 
   def logger
     @logger ||= Logger.new(STDOUT)

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -4,16 +4,15 @@ require "yaml"
 
 class SpecialRoutePublisher
   def self.publish_special_routes
-    logger = Logger.new(STDOUT)
-    publishing_api = GdsApi::PublishingApiV2.new(
-      Plek.find("publishing-api"),
-      bearer_token: ENV.fetch("PUBLISHING_API_BEARER_TOKEN", "example"),
-    )
-    time = (Time.respond_to?(:zone) && Time.zone) || Time
     special_routes = load_special_routes
+    new.publish_routes(special_routes)
+  end
+
+  def publish_routes(routes)
+    time = (Time.respond_to?(:zone) && Time.zone) || Time
 
     # rubocop:disable Metrics/BlockLength
-    special_routes.each do |route|
+    routes.each do |route|
       begin
         type = route.fetch(:type, "exact")
 
@@ -62,4 +61,15 @@ class SpecialRoutePublisher
     YAML.load_file("./data/special_routes.yaml")
   end
   private_class_method :load_special_routes
+
+  def logger
+    @logger ||= Logger.new(STDOUT)
+  end
+
+  def publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.find("publishing-api"),
+      bearer_token: ENV.fetch("PUBLISHING_API_BEARER_TOKEN", "example"),
+    )
+  end
 end

--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -10,83 +10,115 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
     allow(logger).to receive(:info)
   end
 
-  let(:api_content_route) do
-    {
-      content_id: "16ca5ac1-7df5-4137-9f83-0270fcfc8bb5",
-      base_path: "/api/content",
-      title: "Content API",
-      description: "API exposing all content on GOV.UK.",
-      type: "prefix",
-      rendering_app: "content-store",
-    }
-  end
-
-  let(:typeless_route) do
-    {
-      content_id: SecureRandom.uuid,
-      base_path: "/typeless-path",
-      title: "Typeless",
-      rendering_app: "content-store",
-    }
-  end
-
-  let(:invalid_route) do
-    {
-      content_id: SecureRandom.uuid,
-      base_path: "/something-that-doesnt-matter",
-    }
-  end
-
-  before do
-    allow(SpecialRoutePublisher).to receive(:load_special_routes).and_return(routes)
-  end
-
-  context "with a valid route" do
-    let(:routes) { [api_content_route] }
-
-    it "calls the Publishing API to reserve a path, put content and publish it" do
-      stub_put_path = stub_request(:put, "#{publishing_api_endpoint}/paths#{api_content_route.fetch(:base_path)}")
-        .with(body: "{\"publishing_app\":\"special-route-publisher\",\"override_existing\":true}")
-
-      stub_put_content = stub_request(:put, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}")
-
-      stub_publish_content = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}/publish")
-        .with(body: "{\"update_type\":null}")
-
-      expect(logger).to receive(:info).with(/Publishing/)
-
-      described_class.publish_special_routes
-
-      expect(stub_put_path).to have_been_requested
-      expect(stub_put_content).to have_been_requested
-      expect(stub_publish_content).to have_been_requested
+  context "Special routes" do
+    let(:api_content_route) do
+      {
+        content_id: "16ca5ac1-7df5-4137-9f83-0270fcfc8bb5",
+        base_path: "/api/content",
+        title: "Content API",
+        description: "API exposing all content on GOV.UK.",
+        type: "prefix",
+        rendering_app: "content-store",
+      }
     end
 
-    context "without a specific type" do
-      let(:routes) { [typeless_route] }
+    let(:typeless_route) do
+      {
+        content_id: SecureRandom.uuid,
+        base_path: "/typeless-path",
+        title: "Typeless",
+        rendering_app: "content-store",
+      }
+    end
 
-      it "calls the Publishing API with an exact type" do
-        stub_request(:put, "#{publishing_api_endpoint}/paths#{typeless_route.fetch(:base_path)}")
+    let(:invalid_route) do
+      {
+        content_id: SecureRandom.uuid,
+        base_path: "/something-that-doesnt-matter",
+      }
+    end
 
-        stub_put_content = stub_request(:put, "#{publishing_api_endpoint}/v2/content/#{typeless_route.fetch(:content_id)}")
-          .with(body: hash_including("routes" => [{ "path" => "/typeless-path", "type" => "exact" }]))
+    before do
+      allow(SpecialRoutePublisher).to receive(:load_special_routes).and_return(routes)
+    end
 
-        stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{typeless_route.fetch(:content_id)}/publish")
+    context "with a valid route" do
+      let(:routes) { [api_content_route] }
+
+      it "calls the Publishing API to reserve a path, put content and publish it" do
+        stub_put_path = stub_request(:put, "#{publishing_api_endpoint}/paths#{api_content_route.fetch(:base_path)}")
+          .with(body: "{\"publishing_app\":\"special-route-publisher\",\"override_existing\":true}")
+
+        stub_put_content = stub_request(:put, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}")
+
+        stub_publish_content = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}/publish")
+          .with(body: "{\"update_type\":null}")
+
+        expect(logger).to receive(:info).with(/Publishing/)
 
         described_class.publish_special_routes
 
+        expect(stub_put_path).to have_been_requested
         expect(stub_put_content).to have_been_requested
+        expect(stub_publish_content).to have_been_requested
+      end
+
+      context "without a specific type" do
+        let(:routes) { [typeless_route] }
+
+        it "calls the Publishing API with an exact type" do
+          stub_request(:put, "#{publishing_api_endpoint}/paths#{typeless_route.fetch(:base_path)}")
+
+          stub_put_content = stub_request(:put, "#{publishing_api_endpoint}/v2/content/#{typeless_route.fetch(:content_id)}")
+            .with(body: hash_including("routes" => [{ "path" => "/typeless-path", "type" => "exact" }]))
+
+          stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{typeless_route.fetch(:content_id)}/publish")
+
+          described_class.publish_special_routes
+
+          expect(stub_put_content).to have_been_requested
+        end
+      end
+    end
+
+    context "with an invalid route" do
+      let(:routes) { [invalid_route] }
+
+      it "logs an error message and carries on" do
+        expect(logger).to receive(:error).with(/Unable/)
+
+        described_class.publish_special_routes
       end
     end
   end
 
-  context "with an invalid route" do
-    let(:routes) { [invalid_route] }
+  context "minor routes coronavirus task" do
+    let(:a_route) do
+      {
+        content_id: SecureRandom.uuid,
+        base_path: "/a-path",
+        title: "A title",
+        rendering_app: "collections",
+        update_type: "major",
+      }
+    end
+    let(:routes) { [a_route] }
 
-    it "logs an error message and carries on" do
-      expect(logger).to receive(:error).with(/Unable/)
+    before do
+      allow(SpecialRoutePublisher).to receive(:load_coronavirus_routes).and_return(routes)
+    end
 
-      described_class.publish_special_routes
+    it "calls the Publishing API with a minor update type" do
+      stub_request(:put, "#{publishing_api_endpoint}/paths#{a_route.fetch(:base_path)}")
+
+      stub_put_content = stub_request(:put, "#{publishing_api_endpoint}/v2/content/#{a_route.fetch(:content_id)}")
+        .with(body: hash_including("update_type" => "minor"))
+
+      stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{a_route.fetch(:content_id)}/publish")
+
+      described_class.minor_update_coronavirus_routes
+
+      expect(stub_put_content).to have_been_requested
     end
   end
 end


### PR DESCRIPTION
Adds tasks to publish the coronavirus landing page with major / minor updates to generate emails (or not)

Worth reviewing [ignoring whitespace](https://github.com/alphagov/special-route-publisher/compare/coronavirus-page?expand=1&w=1) because I added a context block around some tests which made everything horrible

I fully expect the title / description to change, though it's correct at present.

https://trello.com/c/pF5Cw662/29-write-task-to-publish-route-to-new-page