### PR TITLE
Add document type to route

### DIFF
--- a/data/coronavirus_routes.yaml
+++ b/data/coronavirus_routes.yaml
@@ -4,3 +4,4 @@
   :description: 'Find out about the government response to coronavirus (COVID-19) and what you need to do.'
   :type: 'exact'
   :rendering_app: 'collections'
+  :document_type: 'answer'

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -78,7 +78,7 @@ class SpecialRoutePublisher
   end
 
   def publishing_api
-    @publishing_api ||= GdsApi::PublishingApiV2.new(
+    @publishing_api ||= GdsApi::PublishingApi.new(
       Plek.find("publishing-api"),
       bearer_token: ENV.fetch("PUBLISHING_API_BEARER_TOKEN", "example"),
     )


### PR DESCRIPTION
This doesn't appear in search unless it's a content document type.

Also resolved a deprecation warning.