### PR TITLE
rubocop: Remove redundant excludes for rules that are fixed upstream

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,3 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
-
-AllCops:
-  Exclude:
-    - Rakefile

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,16 @@
-require_relative 'lib/special_route_publisher'
+require_relative "lib/special_route_publisher"
 
-begin
-  require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new(:spec)
-rescue LoadError
-end
-
-desc 'Publish special routes to the Publishing API'
+desc "Publish special routes to the Publishing API"
 task :publish_special_routes do
   SpecialRoutePublisher.publish_special_routes
 end
 
-desc 'Lint ruby'
+desc "Run tests"
+task :spec do
+  sh "bundle exec rspec"
+end
+
+desc "Lint ruby"
 task :lint do
   sh "bundle exec rubocop --format clang"
 end


### PR DESCRIPTION
- The `rubocop-govuk` gem has moved on a bit since this was written, it
  seems. There's nothing glaringly bad in the Rakefile that can't be
  fixed. So auto-fix everything we can, and...

Change RSpec Rake task to fix RuboCop offense

- This is simpler than requiring `rspec/core/rake_task` and rescuing
  the `LoadError` if not in test or dev - RuboCop was moaning about
  that:

```
lib/tasks/rspec.rake:7:1: W: Lint/SuppressedException:
```
