### PR TITLE
Update Bundler to 2.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,4 +122,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
This app runs on Ruby 2.7.1 which has default Bundler 2.1.4. Makes sense to use that version