### PR TITLE
Publish local lockdown finder content-item

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 Publishes special routes to the Publishing API on behalf of other apps.
 
-## Running the rake task
+## Running the rake tasks
+
+To publish all routes:
 
 `PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_special_routes`
+
+To publish one route:
+
+`PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_one_route["/base-path"]`
 
 ## Licence
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,11 @@ task :publish_special_routes do
   SpecialRoutePublisher.publish_special_routes
 end
 
+desc "Publish a single special route to the Publishing API"
+task :publish_one_special_route, [:base_path] => :environment do |_, args|
+  SpecialRoutePublisher.publish_one_route(args.base_path)
+end
+
 desc "Run tests"
 task :spec do
   sh "bundle exec rspec"

--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -26,3 +26,8 @@
   :description: 'Handles government uploads paths.'
   :type: 'prefix'
   :rendering_app: 'government-frontend'
+
+- :content_id: '37a1eea3-e3b9-4bc3-8173-bc8afde9dd2d'
+  :base_path: '/find-coronavirus-local-restrictions'
+  :title: 'Find out the coronavirus restrictions in a local area'
+  :rendering_app: 'collections'

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -7,6 +7,16 @@ class SpecialRoutePublisher
     new.publish_routes(load_special_routes)
   end
 
+  def self.publish_one_route(base_path)
+    routes = load_special_routes.select { |route| route[:base_path] == base_path }
+
+    if routes.any?
+      new.publish_routes(routes)
+    else
+      puts "Route needs to be added to /data/special_routes.yaml"
+    end
+  end
+
   def publish_routes(routes)
     time = (Time.respond_to?(:zone) && Time.zone) || Time
     routes.each do |route|


### PR DESCRIPTION
Trello: https://trello.com/c/EUGVdXmo

# What?

- Adds a local restrictions lookup as a special route. 
- Adds a rake task to only publish one route, rather than all of them

# Why?

The local restrictions postcode lookup is being built in collections. 
At the moment there is no publishing app for this lookup, so we need a way to publish the content-item.