### PR TITLE
Add GOV.UK Account routes for Transition Checker

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -20,6 +20,36 @@
   :title: 'Transition period: sign up for email alerts'
   :rendering_app: 'finder-frontend'
 
+- :content_id: 'b0b1aa86-b992-4aa8-b0d8-ac9936aca660'
+  :base_path: '/transition-check/login'
+  :title: 'Transition period: login to GOV.UK Account'
+  :rendering_app: 'finder-frontend'
+
+- :content_id: 'e5977a8b-1811-424e-a59f-69b83a3ed455'
+  :base_path: '/transition-check/login/callback'
+  :title: 'Transition period: login to GOV.UK Account'
+  :rendering_app: 'finder-frontend'
+
+- :content_id: '9025d362-d5e2-4211-abac-77eb0963fe47'
+  :base_path: '/transition-check/logout'
+  :title: 'Transition period: logout from GOV.UK Account'
+  :rendering_app: 'finder-frontend'
+
+- :content_id: 'c8a24981-e4ea-478d-97a9-2d3d8700fc5e'
+  :base_path: '/transition-check/save-your-results'
+  :title: 'Transition period: save results to GOV.UK Account'
+  :rendering_app: 'finder-frontend'
+
+- :content_id: 'b3395546-3a26-4321-93ae-adea88722014'
+  :base_path: '/transition-check/saved-results'
+  :title: 'Transition period: retrieve results from GOV.UK Account'
+  :rendering_app: 'finder-frontend'
+
+- :content_id: '6c8ace7e-d00d-430b-a71a-86a3cbbab0cb'
+  :base_path: '/transition-check/edit-saved-results'
+  :title: 'Transition period: edit results from GOV.UK Account'
+  :rendering_app: 'finder-frontend'
+
 - :content_id: '5a0ca87e-0e91-4d4c-bd26-29feb24f98ab'
   :base_path: '/government/uploads'
   :title: 'Government Uploads'


### PR DESCRIPTION
These routes will allow users to login, logout, save their responses, retrieve their responses and edit their responses for the Transition Checker.

Trello card: https://trello.com/c/F2pCU73B