### PR TITLE
Remove environment from publish_one_special_route

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :publish_special_routes do
 end
 
 desc "Publish a single special route to the Publishing API"
-task :publish_one_special_route, [:base_path] => :environment do |_, args|
+task :publish_one_special_route, [:base_path] do |_, args|
   SpecialRoutePublisher.publish_one_route(args.base_path)
 end
 


### PR DESCRIPTION
publish_one_special_route is being run by a Jenkins, however that job
can't run "environment" so we need to removed it:

```
+ bundle exec rake publish_one_special_route[/find-coronavirus-local-restrictions]
rake aborted!
Don't know how to build task 'environment' (See the list of available tasks with `rake --tasks`)
/var/lib/jenkins/bundles/Publish_Single_Special_Route/ruby/2.7.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/lib/rbenv/versions/2.7.1/bin/bundle:23:in `load'
/usr/lib/rbenv/versions/2.7.1/bin/bundle:23:in `<main>'
Tasks: TOP => publish_one_special_route
(See full trace by running task with --trace)
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```

See: https://deploy.integration.publishing.service.gov.uk/job/Publish_Single_Special_Route/2/console