### PR TITLE
Make special route appear in search

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -61,3 +61,5 @@
   :base_path: '/find-coronavirus-local-restrictions'
   :title: 'Find out the coronavirus restrictions in a local area'
   :rendering_app: 'collections'
+  :document_type: 'answer'
+  :description: 'Find out the Local COVID Alert Level for an area. Search by postcode.'


### PR DESCRIPTION
The special_route format does not appear in search, because it may be used for routes which don't present information to users (like endpoints for POST requests, or prefix routes which are then handled by apps downstream).

Using the answer format will allow this route to appear in search with a decent boost. This will also mean that it appears in sitemap.xml which helps external visibility. ([Document type is used for both `document_type` and `schema_name`](https://github.com/alphagov/special-route-publisher/blob/master/lib/special_route_publisher.rb#L40-L41))

I've used the description from the metatags on the page.