### PR TITLE
Add /sign-in, callback and sign out routes

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -5,6 +5,21 @@
   :type: 'prefix'
   :rendering_app: 'content-store'
 
+- :content_id: 'b6bb372b-3c4e-4a21-98a6-ffbf2ea5dc9e'
+  :base_path: '/sign-in'
+  :title: 'Sign In to GOV.UK'
+  :rendering_app: 'frontend'
+
+- :content_id: 'f04c45a7-c20b-4f66-a485-dc997a6a3b6d'
+  :base_path: '/sign-in/callback'
+  :title: 'Sign In to GOV.UK (OAuth Callback)'
+  :rendering_app: 'frontend'
+
+- :content_id: '7ee16fff-900d-4f5d-bd0a-62fdaa1ad3b6'
+  :base_path: '/sign-out'
+  :title: 'Sign Out from GOV.UK'
+  :rendering_app: 'frontend'
+
 - :content_id: '74738e19-d036-48a4-9a35-d0bc40e3fcbc'
   :base_path: '/transition-check/questions'
   :title: 'Transition period: check what you need to do now'


### PR DESCRIPTION
[a part of trello](https://trello.com/c/RaI017p6/675-add-new-public-facing-oauth-endpoints-to-frontend)

A part of the work to broaden the transition checker login prototype to
the whole of GOV.UK. As outlined in [RFC#134][1] we are moving sign in
and sign out paths from being nested in finder-frontend (which would be
strange for a GOV.UK-wide login!) onto their own paths.

See the RFC for more detail on these two paths:
- [Sign in][2]
- [Sign in callback][3]
- [Sign out][4]

[1]: https://github.com/alphagov/govuk-rfcs/pull/134
[2]: https://github.com/alphagov/govuk-rfcs/pull/134/files#diff-f5a6037308ea735f2a6e63b3080e78792499608bcad7386a49cf94799634d1beR224
[3]: https://github.com/alphagov/govuk-rfcs/pull/134/files#diff-f5a6037308ea735f2a6e63b3080e78792499608bcad7386a49cf94799634d1beR236
[4]: https://github.com/alphagov/govuk-rfcs/pull/134/files#diff-f5a6037308ea735f2a6e63b3080e78792499608bcad7386a49cf94799634d1beR243