### PR TITLE
Add a rake task to unpublish a special route

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,11 @@ task :publish_one_special_route, [:base_path] do |_, args|
   SpecialRoutePublisher.publish_one_route(args.base_path)
 end
 
+desc "Unpublish a single special route, with a type of 'gone'"
+task :unpublish_one_special_route, [:base_path] do |_, args|
+  SpecialRoutePublisher.unpublish_one_route(args.base_path)
+end
+
 desc "Run tests"
 task :spec do
   sh "bundle exec rspec"

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -17,6 +17,19 @@ class SpecialRoutePublisher
     end
   end
 
+  def self.unpublish_one_route(base_path)
+    routes = load_special_routes.select { |route| route[:base_path] == base_path }
+
+    if routes.any?
+      new.publishing_api.unpublish(
+        routes.first.fetch(:content_id),
+        type: "gone",
+      )
+    else
+      puts "Route needs to be added to /data/special_routes.yaml"
+    end
+  end
+
   def publish_routes(routes)
     time = (Time.respond_to?(:zone) && Time.zone) || Time
     routes.each do |route|

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -8,21 +8,21 @@ class SpecialRoutePublisher
   end
 
   def self.publish_one_route(base_path)
-    routes = load_special_routes.select { |route| route[:base_path] == base_path }
+    route = load_special_routes.find { |r| r[:base_path] == base_path }
 
-    if routes.any?
-      new.publish_routes(routes)
+    if route
+      new.publish_routes([route])
     else
       puts "Route needs to be added to /data/special_routes.yaml"
     end
   end
 
   def self.unpublish_one_route(base_path)
-    routes = load_special_routes.select { |route| route[:base_path] == base_path }
+    route = load_special_routes.find { |r| r[:base_path] == base_path }
 
-    if routes.any?
+    if route
       new.publishing_api.unpublish(
-        routes.first.fetch(:content_id),
+        route.fetch(:content_id),
         type: "gone",
       )
     else

--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -90,5 +90,22 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
         described_class.publish_special_routes
       end
     end
+
+    context "unpublishing a route" do
+      let(:routes) { [api_content_route, typeless_route] }
+
+      it "unpublishes just the named route" do
+        stub_unpublish = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{typeless_route[:content_id]}/unpublish")
+          .with(body: "{\"type\":\"gone\"}")
+
+        described_class.unpublish_one_route(typeless_route[:base_path])
+
+        expect(stub_unpublish).to have_been_requested
+      end
+
+      it "doesn't call the publishing API to unpublish a route not in the routes config" do
+        described_class.unpublish_one_route("/some-base-path-not-in-the-config")
+      end
+    end
   end
 end

--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -94,17 +94,13 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
     context "unpublishing a route" do
       let(:routes) { [api_content_route, typeless_route] }
 
-      it "unpublishes just the named route" do
+      it "unpublishes the named route" do
         stub_unpublish = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{typeless_route[:content_id]}/unpublish")
           .with(body: "{\"type\":\"gone\"}")
 
         described_class.unpublish_one_route(typeless_route[:base_path])
 
         expect(stub_unpublish).to have_been_requested
-      end
-
-      it "doesn't call the publishing API to unpublish a route not in the routes config" do
-        described_class.unpublish_one_route("/some-base-path-not-in-the-config")
       end
     end
   end


### PR DESCRIPTION
The transition checker login & logout pages are no more, they have
moved to frontend, and so their routes need unpublishing.