### PR TITLE
Rewrite README to favour GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,33 @@
 
 Publishes special routes to the Publishing API on behalf of other apps.
 
+## Technical documentation
+
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the tests and rake commands on your local machine. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
+
+**Use GOV.UK Docker to run any commands that follow.**
+
+## Running the test suite
+
+```
+bundle exec rake
+```
+
 ## Running the rake tasks
+
+_You will need to start Publishing API and Content Store to run the following commands locally._
 
 To publish all routes:
 
-`PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_special_routes`
+```
+env PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_special_routes
+```
 
 To publish one route:
 
-`PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_one_route["/base-path"]`
+```
+env PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_one_route["/base-path"]
+```
 
 ## Licence
 


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This deviates slightly from the wording we've used in other repos
[1], since it's not really possible to "run" this app. Instead, I've
tweaked the section about publishing routes:

- To say which dependencies need to be started manually.
- Prefix "env" (see [2]), which also works with GOV.UK Docker.

[1]: https://github.com/alphagov/email-alert-api#technical-documentation
[2]: https://github.com/alphagov/govuk-docker/blob/master/docs/how-tos.md#how-to-set-environment-variables