### PR TITLE
Allow routes to be unpublished with a redirect

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,9 +10,9 @@ task :publish_one_special_route, [:base_path] do |_, args|
   SpecialRoutePublisher.publish_one_route(args.base_path)
 end
 
-desc "Unpublish a single special route, with a type of 'gone'"
-task :unpublish_one_special_route, [:base_path] do |_, args|
-  SpecialRoutePublisher.unpublish_one_route(args.base_path)
+desc "Unpublish a single special route, with a type of 'gone' or 'redirect'"
+task :unpublish_one_special_route, [:base_path, :alternative_path] do |_, args|
+  SpecialRoutePublisher.unpublish_one_route(args.base_path, args.alternative_path)
 end
 
 desc "Run tests"

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -17,10 +17,16 @@ class SpecialRoutePublisher
     end
   end
 
-  def self.unpublish_one_route(base_path)
+  def self.unpublish_one_route(base_path, alternative_path = nil)
     route = load_special_routes.find { |r| r[:base_path] == base_path }
 
-    if route
+    if route && alternative_path
+      new.publishing_api.unpublish(
+        route.fetch(:content_id),
+        type: "redirect",
+        alternative_path: alternative_path,
+      )
+    elsif route
       new.publishing_api.unpublish(
         route.fetch(:content_id),
         type: "gone",

--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -102,6 +102,16 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
 
         expect(stub_unpublish).to have_been_requested
       end
+
+      it "redirects the route" do
+        alternative_path = "/hello-there"
+        stub_unpublish = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{typeless_route[:content_id]}/unpublish")
+          .with(body: "{\"type\":\"redirect\",\"alternative_path\":\"#{alternative_path}\"}")
+
+        described_class.unpublish_one_route(typeless_route[:base_path], alternative_path)
+
+        expect(stub_unpublish).to have_been_requested
+      end
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/XjIYqQ55

# What's changed?

Update the `unpublish_one_special_route` to redirect the page if an alternative path is provided.

# Why?

The code for the local restrictions is being removed. The postcode checker has been offline for a while now, but to prevent users from accessing it, we added a redirect to in the [controller](https://github.com/alphagov/collections/blob/main/app/controllers/coronavirus_local_restrictions_controller.rb#L9). As the code is being removed we need to add the redirect properly in the content item.