### PR TITLE
[Do not merge] Remove special route for postcode checker

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -71,10 +71,3 @@
   :description: 'Handles government uploads paths.'
   :type: 'prefix'
   :rendering_app: 'government-frontend'
-
-- :content_id: '37a1eea3-e3b9-4bc3-8173-bc8afde9dd2d'
-  :base_path: '/find-coronavirus-local-restrictions'
-  :title: 'Find out the coronavirus restrictions in a local area'
-  :rendering_app: 'collections'
-  :document_type: 'answer'
-  :description: 'Use the postcode checker to find out the tier that your local area is in.'


### PR DESCRIPTION
Trello: https://trello.com/c/XjIYqQ55

# What's changed?

Remove special route for local restrictions postcode checker.

# Why?

The local restrictions postcode checker hasn't been live since the
begining of January when England went into a national lockdown. At the
moment it looks unlikely that local restrictions will come back again in
their previous form and it's not good for the code base to keep stale
code lying around. The code for the postcode checker is being removed in
https://github.com/alphagov/collections/pull/2380.