### PR TITLE
Add `/search/latest` route

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -41,3 +41,8 @@
   :description: 'Handles government uploads paths.'
   :type: 'prefix'
   :rendering_app: 'government-frontend'
+
+- :content_id: 'eb56dbca-be0b-4381-8dac-0c9de8a3ed7e'
+  :base_path: '/search/latest'
+  :title: 'Search'
+  :rendering_app: 'finder-frontend'


### PR DESCRIPTION
In https://github.com/alphagov/finder-frontend/pull/2800, a new route was introduced the replace the "Latest Documents" page that is currently rendered by Whitehall. This route acts as a redirect to an existing finder, so will never be published by an application.

This adds the content item, so the finder can be accessed.

[Trello card](https://trello.com/c/93adHMBQ)