### PR TITLE
Add request-accessible-format to routes

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -46,3 +46,8 @@
   :base_path: '/search/latest'
   :title: 'Search'
   :rendering_app: 'finder-frontend'
+
+- :content_id: '34761d23-eafa-4025-82bf-0d127e06e8be'
+  :base_path: '/contact/govuk/request-accessible-format'
+  :rendering_app: 'feedback'
+  :title: 'Request accessible format'


### PR DESCRIPTION
Adds the Feedback app's `contact/govuk/request-accessible-format` route to allow us to unpublish and mark the route as `gone`

[trello](https://trello.com/c/tU8GEALb/1405-unpublish-request-accessible-format-form)