### PR TITLE
Remove signin route to remove clash

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -38,11 +38,6 @@
   :title: 'Search'
   :rendering_app: 'finder-frontend'
 
-- :content_id: 'b6bb372b-3c4e-4a21-98a6-ffbf2ea5dc9e'
-  :base_path: '/sign-in'
-  :title: 'Sign In to GOV.UK'
-  :rendering_app: 'frontend'
-
 - :content_id: 'f04c45a7-c20b-4f66-a485-dc997a6a3b6d'
   :base_path: '/sign-in/callback'
   :title: 'Sign In to GOV.UK (OAuth Callback)'


### PR DESCRIPTION
https://trello.com/c/cI0j7qI3/1465-fix-accounts-sorting-hat-page

The page at /sign-in is currently in an incorrect state and needs to be republished via Account API, this needs removing to prevent a revert again later.