### PR TITLE
Add past foreign secretaries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.23
+   2.3.7

--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -55,3 +55,13 @@
   :base_path: '/sign-out'
   :title: 'Sign Out from GOV.UK'
   :rendering_app: 'frontend'
+
+- :content_id: '93f4dedc-f8a1-4ff4-9a61-fb1b5c5acaa5'
+  :base_path: '/government/history/past-foreign-secretaries'
+  :title: 'Past foreign secretaries pages'
+  :description: 'Handles pages for past foreign secretaries.'
+  :type: 'prefix'
+  :rendering_app: 'whitehall-frontend'
+  :links:
+    :parent:
+      - 'e46b25e9-d47f-4b93-8466-682b73627db3'

--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -26,6 +26,14 @@
   :description: 'Find out what support is available to help with the cost of living. This includes income and disability benefits, bills and allowances, childcare, housing and transport.'
   :rendering_app: 'collections'
 
+- :content_id: 'ad0e3f36-0fee-4ac0-9db6-6b6dfa735752'
+  :base_path: '/government/history/past-chancellors'
+  :title: 'Past Chancellors of the Exchequer'
+  :rendering_app: 'whitehall-frontend'
+  :links:
+    :parent:
+      - 'db95a864-874f-4f50-a483-352a5bc7ba18'
+
 - :content_id: '5a0ca87e-0e91-4d4c-bd26-29feb24f98ab'
   :base_path: '/government/uploads'
   :title: 'Government Uploads'

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -74,10 +74,12 @@ class SpecialRoutePublisher
         update_type: route.fetch(:update_type, "major"),
       )
 
-      publishing_api.patch_links(
-        route.fetch(:content_id),
-        links: route.fetch(:links, {}),
-      )
+      if route[:links]
+        publishing_api.patch_links(
+          route.fetch(:content_id),
+          links: route[:links],
+        )
+      end
 
       publishing_api.publish(route.fetch(:content_id))
     rescue KeyError => e

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -74,6 +74,11 @@ class SpecialRoutePublisher
         update_type: route.fetch(:update_type, "major"),
       )
 
+      publishing_api.patch_links(
+        route.fetch(:content_id),
+        links: route.fetch(:links, {}),
+      )
+
       publishing_api.publish(route.fetch(:content_id))
     rescue KeyError => e
       logger.error("Unable to publish #{route} due to an error: #{e}")

--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
 
       it "calls the Publishing API to reserve a path, put content, patch links and publish it" do
         stub_put_path = stub_request(:put, "#{publishing_api_endpoint}/paths#{api_content_route.fetch(:base_path)}")
-          .with(body: "{\"publishing_app\":\"special-route-publisher\",\"override_existing\":true}")
+          .with(body: {
+            publishing_app: "special-route-publisher",
+            override_existing: true,
+          }.to_json)
 
         stub_put_content = stub_request(:put, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}")
 
@@ -66,7 +69,9 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
           }.to_json)
 
         stub_publish_content = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}/publish")
-          .with(body: "{\"update_type\":null}")
+          .with(body: {
+            update_type: nil,
+          }.to_json)
 
         expect(logger).to receive(:info).with(/Publishing/)
 
@@ -111,7 +116,9 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
 
       it "unpublishes the named route" do
         stub_unpublish = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{typeless_route[:content_id]}/unpublish")
-          .with(body: "{\"type\":\"gone\"}")
+          .with(body: {
+            type: "gone",
+          }.to_json)
 
         described_class.unpublish_one_route(typeless_route[:base_path])
 
@@ -121,7 +128,10 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
       it "redirects the route" do
         alternative_path = "/hello-there"
         stub_unpublish = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{typeless_route[:content_id]}/unpublish")
-          .with(body: "{\"type\":\"redirect\",\"alternative_path\":\"#{alternative_path}\"}")
+          .with(body: {
+            type: "redirect",
+            alternative_path:,
+          }.to_json)
 
         described_class.unpublish_one_route(typeless_route[:base_path], alternative_path)
 


### PR DESCRIPTION
(Sorry about the name of the branch, I keep getting confused between past chancellors and past foreign secretaries)

As part of work to migrate the rendering of past foreign secretaries index page (https://www.gov.uk/government/history/past-foreign-secretaries) and individual foreign secretary pages (e.g. https://www.gov.uk/government/history/past-foreign-secretaries/edward-wood) to collections, we will need a content item for these pages.

As this is a prefix route, it will handle both the individual pages at /government/history/past-foreign-secretaries/:id and the index page.

In this PR, we retain whitehall-frontend as the rendering app. This will allow us to develop the rendering code with a content item, without switching the live rendering over. When the rendering work is complete, we will update this code to have a rendering app of collections.

Depends on [PR to allow special routes to have links](https://github.com/alphagov/special-route-publisher/pull/240)

[Trello](https://trello.com/c/qmCFBhZF/404-migrate-past-foreign-secretaries-page)