### PR TITLE
Add content item for Past Chancellors page

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -26,6 +26,14 @@
   :description: 'Find out what support is available to help with the cost of living. This includes income and disability benefits, bills and allowances, childcare, housing and transport.'
   :rendering_app: 'collections'
 
+- :content_id: 'ac47f738-b6c3-4369-8d22-ce143c947442'
+  :base_path: '/government/history/past-chancellors'
+  :title: 'Past Chancellors of the Exchequer'
+  :rendering_app: 'whitehall-frontend'
+  :links:
+    :parent:
+      - 'db95a864-874f-4f50-a483-352a5bc7ba18'
+
 - :content_id: '5a0ca87e-0e91-4d4c-bd26-29feb24f98ab'
   :base_path: '/government/uploads'
   :title: 'Government Uploads'

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -74,6 +74,13 @@ class SpecialRoutePublisher
         update_type: route.fetch(:update_type, "major"),
       )
 
+      if route[:links]
+        publishing_api.patch_links(
+          route.fetch(:content_id),
+          links: route[:links],
+        )
+      end
+
       publishing_api.publish(route.fetch(:content_id))
     rescue KeyError => e
       logger.error("Unable to publish #{route} due to an error: #{e}")

--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -47,12 +47,17 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
 
       it "calls the Publishing API to reserve a path, put content and publish it" do
         stub_put_path = stub_request(:put, "#{publishing_api_endpoint}/paths#{api_content_route.fetch(:base_path)}")
-          .with(body: "{\"publishing_app\":\"special-route-publisher\",\"override_existing\":true}")
+          .with(body: {
+            publishing_app: "special-route-publisher",
+            override_existing: true,
+          }.to_json)
 
         stub_put_content = stub_request(:put, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}")
 
         stub_publish_content = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}/publish")
-          .with(body: "{\"update_type\":null}")
+          .with(body: {
+            update_type: nil,
+          }.to_json)
 
         expect(logger).to receive(:info).with(/Publishing/)
 
@@ -139,7 +144,9 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
 
       it "unpublishes the named route" do
         stub_unpublish = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{typeless_route[:content_id]}/unpublish")
-          .with(body: "{\"type\":\"gone\"}")
+          .with(body: {
+            type: "gone",
+          }.to_json)
 
         described_class.unpublish_one_route(typeless_route[:base_path])
 
@@ -149,7 +156,10 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
       it "redirects the route" do
         alternative_path = "/hello-there"
         stub_unpublish = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{typeless_route[:content_id]}/unpublish")
-          .with(body: "{\"type\":\"redirect\",\"alternative_path\":\"#{alternative_path}\"}")
+          .with(body: {
+            type: "redirect",
+            alternative_path:,
+          }.to_json)
 
         described_class.unpublish_one_route(typeless_route[:base_path], alternative_path)
 

--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -79,6 +79,49 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
           expect(stub_put_content).to have_been_requested
         end
       end
+
+      context "with links" do
+        let(:links) do
+          {
+            parent: %w[
+              718d2881-3f19-44c2-acf0-3e91dc20f220
+            ],
+          }
+        end
+
+        it "calls patch links" do
+          api_content_route[:links] = links
+
+          stub_put_path = stub_request(:put, "#{publishing_api_endpoint}/paths#{api_content_route.fetch(:base_path)}")
+            .with(body: {
+              publishing_app: "special-route-publisher",
+              override_existing: true,
+            }.to_json)
+
+          stub_put_content = stub_request(:put, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}")
+
+          stub_patch_links = stub_request(:patch, "#{publishing_api_endpoint}/v2/links/#{api_content_route.fetch(:content_id)}")
+            .with(body: {
+              links: {
+                parent: %w[
+                  718d2881-3f19-44c2-acf0-3e91dc20f220
+                ],
+              },
+            }.to_json)
+
+          stub_publish_content = stub_request(:post, "#{publishing_api_endpoint}/v2/content/#{api_content_route.fetch(:content_id)}/publish")
+            .with(body: {
+              update_type: nil,
+            }.to_json)
+
+          described_class.publish_special_routes
+
+          expect(stub_put_path).to have_been_requested
+          expect(stub_put_content).to have_been_requested
+          expect(stub_patch_links).to have_been_requested
+          expect(stub_publish_content).to have_been_requested
+        end
+      end
     end
 
     context "with an invalid route" do


### PR DESCRIPTION
This is currently rendered by Whitehall, but will be migrated to Collections.

We need a content item so we can test the rendering in Collections before migrating the public rendering.

The parent link is being added to ensure the breadcrumb is correctly displayed on the page.

In a later PR, we will switch the rendering app to Collections.

[Trello card](https://trello.com/c/PgJxJILW)