### PR TITLE
Change rendering app for Past Chancellors page

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -29,7 +29,7 @@
 - :content_id: 'ac47f738-b6c3-4369-8d22-ce143c947442'
   :base_path: '/government/history/past-chancellors'
   :title: 'Past Chancellors of the Exchequer'
-  :rendering_app: 'whitehall-frontend'
+  :rendering_app: 'collections'
   :links:
     :parent:
       - 'db95a864-874f-4f50-a483-352a5bc7ba18'


### PR DESCRIPTION
Now the rendering of this page has been migrated from Whitehall to Collections, we need to update the rendering application so Collections will render the page.

Not to be merged until https://github.com/alphagov/collections/pull/3118 is merged.

[Trello card](https://trello.com/c/PgJxJILW)