### PR TITLE
Add special routes for past foreign secretaries

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -34,6 +34,15 @@
     :parent:
       - 'db95a864-874f-4f50-a483-352a5bc7ba18'
 
+- :content_id: 'e46b25e9-d47f-4b93-8466-682b73627db3'
+  :base_path: '/government/history/past-foreign-secretaries'
+  :title: 'Past Foreign Secretaries'
+  :type: 'prefix'
+  :rendering_app: 'whitehall-frontend'
+  :links:
+    :parent:
+      - 'db95a864-874f-4f50-a483-352a5bc7ba18'
+
 - :content_id: '5a0ca87e-0e91-4d4c-bd26-29feb24f98ab'
   :base_path: '/government/uploads'
   :title: 'Government Uploads'


### PR DESCRIPTION
As part of work to migrate the rendering of past foreign secretaries index page (https://www.gov.uk/government/history/past-foreign-secretaries) and individual foreign secretary pages (e.g. https://www.gov.uk/government/history/past-foreign-secretaries/edward-wood) to collections, we will need a content item for these pages.

As this is a prefix route, it will handle both the individual pages at /government/history/past-foreign-secretaries/:id and the index page.

In this PR, we retain whitehall-frontend as the rendering app. This will allow us to develop the rendering code with a content item, without switching the live rendering over. When the rendering work is complete, we will update this code to have a rendering app of collections.

Depends on [PR to allow special routes to have links](https://github.com/alphagov/special-route-publisher/pull/240)

[Trello](https://trello.com/c/qmCFBhZF/404-migrate-past-foreign-secretaries-page)