### PR TITLE
Update rendering app for past foreign secretaries

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -38,7 +38,7 @@
   :base_path: '/government/history/past-foreign-secretaries'
   :title: 'Past Foreign Secretaries'
   :type: 'prefix'
-  :rendering_app: 'whitehall-frontend'
+  :rendering_app: 'collections'
   :links:
     :parent:
       - 'db95a864-874f-4f50-a483-352a5bc7ba18'


### PR DESCRIPTION
We are moving rendering for past foreign secretary pages (both an index and some individual pages) to collections, as part of work to move rendering away from Whitehall.

Depends on https://github.com/alphagov/collections/pull/3113 ✅ 

[Trello](https://trello.com/c/qmCFBhZF/404-migrate-past-foreign-secretaries-page)