### PR TITLE
Remove /cost-of-living special route

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -20,12 +20,6 @@
   :type: "prefix"
   :rendering_app: "content-store"
 
-- :content_id: "740772f4-7aa4-4f55-aab6-0fba188dc517"
-  :base_path: "/cost-of-living"
-  :title: "Cost of living support"
-  :description: "Find out what support is available to help with the cost of living. This includes income and disability benefits, bills and allowances, childcare, housing and transport."
-  :rendering_app: "collections"
-
 - :content_id: "ac47f738-b6c3-4369-8d22-ce143c947442"
   :base_path: "/government/history/past-chancellors"
   :title: "Past Chancellors of the Exchequer"


### PR DESCRIPTION
"Cost of living support" special navigation page is being removed. The /cost-of-living base path will be used by "Cost of living support" guide https://publisher.publishing.service.gov.uk/editions/63f4a6428fa8f567b3d90c12

https://trello.com/c/j34Whcl4/1709-shut-down-cost-of-living-navigation-page-l