### PR TITLE
Add `search/consultations` and `search/statistics-announcements` routes

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -44,6 +44,16 @@
   :type: "prefix"
   :rendering_app: "government-frontend"
 
+- :content_id: "c3b020bf-bc77-4213-afa2-b45eac30f2dc"
+  :base_path: "/search/consultations"
+  :title: "Policy papers and consultations"
+  :rendering_app: "finder-frontend"
+
+- :content_id: "e38cc2da-cea5-4585-9aaa-454c109a51e0"
+  :base_path: "/search/statistics-announcements"
+  :title: "Research and statistics"
+  :rendering_app: "finder-frontend"
+
 - :content_id: "eb56dbca-be0b-4381-8dac-0c9de8a3ed7e"
   :base_path: "/search/latest"
   :title: "Search"


### PR DESCRIPTION
In https://github.com/alphagov/finder-frontend/pull/3050 2 new routes were added to replace the `government/consultations` and `government/statistics/announcements` redirects that were previously handled by Whitehall, to pages whose rendering was previously moved to finder-frontend.

These routes both act as redirects to existing finders, so will never be published. 

Trello: https://trello.com/c/SmdAt9SX/523-migrate-redirect-logic-from-whitehall-to-finder-frontend