### PR TITLE
Remove obsolete Licence Data API route

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -59,11 +59,6 @@
   :title: "Search"
   :rendering_app: "finder-frontend"
 
-- :content_id: "b3fbd4e1-40dc-4f53-8c1f-d7e24bb61ee2"
-  :base_path: "/licence-finder/licences-api"
-  :title: "Licence Data API"
-  :rendering_app: "licencefinder"
-
 - :content_id: "f04c45a7-c20b-4f66-a485-dc997a6a3b6d"
   :base_path: "/sign-in/callback"
   :title: "Sign In to GOV.UK (OAuth Callback)"


### PR DESCRIPTION
We don't use this route any more, and it will vanish when licence finder is retired, so simplest to remove it now (and unpublish manually using the unpublish_one_special_route rake task)