### PR TITLE
Move publishing of all special routes from frontend

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -68,3 +68,14 @@
   :base_path: "/sign-out"
   :title: "Sign Out from GOV.UK"
   :rendering_app: "frontend"
+
+- :content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
+  :base_path: "/"
+  :document_type: "homepage"
+  :title: "GOV.UK homepage"
+  :rendering_app: "frontend"
+  :links:
+    :organisations:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+    :primary_publishing_organisation:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"

--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -79,3 +79,48 @@
       - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
     :primary_publishing_organisation:
       - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+
+- :content_id: "caf90fb7-11e3-4f8e-9a5d-b83283c91533"
+  :base_path: "/tour"
+  :title: "GOV.UK introductory page"
+  :description: "A description of the various sections of GOV.UK and their uses."
+  :rendering_app: "frontend"
+
+- :content_id: "3c7060f7-9efa-47be-bd36-0326f3fa4f04"
+  :base_path: "/help"
+  :title: "Help using GOV.UK"
+  :description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy notice and terms and conditions of use."
+  :links:
+    :ordered_related_items:
+      - "58b05bc2-fde5-4a0b-af73-8edc532674f8"
+  :rendering_app: "frontend"
+
+- :content_id: "a4d4e755-3d75-4b19-b120-a638a6d79ba8"
+  :base_path: "/help/ab-testing"
+  :title: "A/B testing on GOV.UK"
+  :description: "This page is being used internally by GOV.UK to make sure A/B testing works."
+  :rendering_app: "frontend"
+
+- :content_id: "220f39ad-d4ad-4b0c-9d40-6c417a1341c0"
+  :base_path: "/help/cookies"
+  :title: "Cookies on GOV.UK"
+  :description: "You can choose which cookies you're happy for GOV.UK to use."
+  :rendering_app: "frontend"
+
+- :content_id: "3c991cea-cdee-4e58-b8d1-d38e7c0e6327"
+  :base_path: "/random"
+  :title: "GOV.UK random page"
+  :rendering_app: "frontend"
+
+- :content_id: "9a86495d-663f-46f8-b4ce-fc9153579338"
+  :base_path: "/roadmap"
+  :title: "GOV.UK Roadmap"
+  :description: "This is GOV.UK's current roadmap. We plan to update it again in the new financial year."
+  :rendering_app: "frontend"
+
+- :content_id: "622fda2b-5fa6-4c84-bc3b-22cd3ff08828"
+  :base_path: "/find-local-council"
+  :title: "Find your local council"
+  :description: "Find your local authority in England, Wales, Scotland and Northern Ireland"
+  :rendering_app: "frontend"
+  :type: "prefix"


### PR DESCRIPTION
Frontend [currently publishes a small number of hard-coded content items](https://github.com/alphagov/frontend/blob/508fabbb05aa3522bad5e0b1a1a3cc318f7cf562/lib/special_route_publisher.rb#L22-L83), including the [homepage](https://github.com/alphagov/frontend/blob/508fabbb05aa3522bad5e0b1a1a3cc318f7cf562/lib/homepage_publisher.rb#L5-L25). Having frontend applications act as publishing applications somewhat breaks the architecture of GOV.UK and is [recorded as tech debt](https://trello.com/b/oPnw6v3r/govuk-tech-debt).

This has been tested on integration, and all these pages on integration are currently published by special routes publisher.

I have checked that:
a) the rendered page looks unchanged; and
b) the only differences in the content item are the publishing app, and the updated at timestamps.

Note that the only route I haven't added into here is the /homepage redirect, which I think better sits in short url manager.

You can compare the pages using the following links:

| Page | Integration (published by special routes publisher) | Production (published by frontend) |
|----|-----|---|
| homepage | https://www.integration.publishing.service.gov.uk/ | https://www.gov.uk/ | 
| tour | https://www.integration.publishing.service.gov.uk/tour | https://www.gov.uk/tour | 
| help | https://www.integration.publishing.service.gov.uk/help | https://www.gov.uk/help | 
| testing | https://www.integration.publishing.service.gov.uk/help/ab-testing | https://www.gov.uk/help/ab-testing | 
| cookies | https://www.integration.publishing.service.gov.uk/help/cookies | https://www.gov.uk/help/cookies | 
| random | https://www.integration.publishing.service.gov.uk/random | https://www.gov.uk/random | 
| roadmap | https://www.integration.publishing.service.gov.uk/roadmap | https://www.gov.uk/roadmap | 
| find local council council | https://www.integration.publishing.service.gov.uk/find-local-council | https://www.gov.uk/find-local-council | 

Once this has been run in all environments, we can [remove the publishing code from frontend](https://github.com/alphagov/frontend/pull/3663).

[Trello](https://trello.com/c/qxxCC57R/1873-stop-frontend-publishing-content-items)