### PR TITLE
Move homepage into a separate file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ rescue LoadError
   # These gems will fail to load outside of dev/test environments
 end
 
-desc "Publish special routes to the Publishing API"
+desc "Publish special routes (except the homepage) to the Publishing API"
 task :publish_special_routes do
   SpecialRoutePublisher.publish_special_routes
 end
@@ -23,6 +23,11 @@ end
 desc "Unpublish a single special route, with a type of 'gone' or 'redirect'"
 task :unpublish_one_special_route, [:base_path, :alternative_path] do |_, args|
   SpecialRoutePublisher.unpublish_one_route(args.base_path, args.alternative_path)
+end
+
+desc "Publish the homepage to the Publishing API"
+task :publish_homepage do
+  SpecialRoutePublisher.publish_homepage
 end
 
 task default: %i[rubocop spec]

--- a/data/homepage.yaml
+++ b/data/homepage.yaml
@@ -1,0 +1,10 @@
+- :content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
+  :base_path: "/"
+  :document_type: "homepage"
+  :title: "GOV.UK homepage"
+  :rendering_app: "frontend"
+  :links:
+    :organisations:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+    :primary_publishing_organisation:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"

--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -69,16 +69,6 @@
   :title: "Sign Out from GOV.UK"
   :rendering_app: "frontend"
 
-- :content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
-  :base_path: "/"
-  :document_type: "homepage"
-  :title: "GOV.UK homepage"
-  :rendering_app: "frontend"
-  :links:
-    :organisations:
-      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
-    :primary_publishing_organisation:
-      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
 
 - :content_id: "caf90fb7-11e3-4f8e-9a5d-b83283c91533"
   :base_path: "/tour"

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -36,6 +36,10 @@ class SpecialRoutePublisher
     end
   end
 
+  def self.publish_homepage
+    new.publish_routes(load_homepage)
+  end
+
   def publish_routes(routes)
     time = (Time.respond_to?(:zone) && Time.zone) || Time
     routes.each do |route|
@@ -89,6 +93,10 @@ class SpecialRoutePublisher
 
   def self.load_special_routes
     YAML.load_file("./data/special_routes.yaml")
+  end
+
+  def self.load_homepage
+    YAML.load_file("./data/homepage.yaml")
   end
 
   def logger


### PR DESCRIPTION
The homepage causes a lot of republishing activity through dependency resolution. Separating it from the rest of the routes means that we won't be republishing it every time all routes are republished, therefore decreasing the chance that we accidentally block up the publishing queues with a lot of unecessary activity.

[Trello](https://trello.com/c/qxxCC57R/1873-stop-frontend-publishing-special-routes)