### PR TITLE
Move  /humans.txt from static with override

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -114,3 +114,10 @@
   :description: "Find your local authority in England, Wales, Scotland and Northern Ireland"
   :rendering_app: "frontend"
   :type: "prefix"
+
+- :content_id: "6e92af59-3a73-4db6-b58b-740a02b229d0"
+  :base_path: "/humans.txt"
+  :title: "humans.txt"
+  :description: "In opposition to robots.txt, humans.txt provides information about GOV.UK to interested readers, such as developers interested in joining GDS."
+  :rendering_app: "static"
+  :override_existing: true


### PR DESCRIPTION
Static is currently pushing this route with a publishing_api rake task, we want to get rid of frontend apps talking to the publishing api, this is the proof of concept as in this trello card:

https://trello.com/c/hJVUjqbs/31-frontend-apps-publish-content-items-to-publishing-api