### PR TITLE
Add special routes for email-alert-frontend

### DIFF
--- a/data/special_routes.yaml
+++ b/data/special_routes.yaml
@@ -121,3 +121,49 @@
   :description: "In opposition to robots.txt, humans.txt provides information about GOV.UK to interested readers, such as developers interested in joining GDS."
   :rendering_app: "static"
   :override_existing: true
+
+- :content_id: "e3bf851b-5df7-441b-8813-f0ec849da35f"
+  :base_path: "/email-signup"
+  :title: "Get email alerts"
+  :description: "Allows users to subscribe to email alerts"
+  :rendering_app: "email-alert-frontend"
+  :override_existing: true
+
+- :content_id: "eb5fad51-f346-4365-be4a-ebc1b25b88f8"
+  :base_path: "/email-signup/confirm"
+  :title: "Get email alerts"
+  :description: "Confirmation page for users subscribing to email alerts"
+  :rendering_app: "email-alert-frontend"
+  :override_existing: true
+
+- :content_id: "ea8a4639-fd68-4e09-8886-dc4c8f4dab7a"
+  :base_path: "/email/unsubscribe"
+  :title: "Email unsubscribe"
+  :description: "Prefix route to allow users to unsubscribe from emails"
+  :rendering_app: "email-alert-frontend"
+  :type: "prefix"
+  :override_existing: true
+
+- :content_id: "1773511a-b3c9-4f37-8692-91a718d5b6ae"
+  :base_path: "/email/subscriptions"
+  :title: "Email - create subscription"
+  :description: "Prefix route to allow users to create email subscriptions"
+  :rendering_app: "email-alert-frontend"
+  :type: "prefix"
+  :override_existing: true
+
+- :content_id: "889e5a6f-d63b-4e10-8ffb-8d3959453285"
+  :base_path: "/email/authenticate"
+  :title: "Email - authenticate"
+  :description: "Prefix route to allow authentication for email subscription management"
+  :rendering_app: "email-alert-frontend"
+  :type: "prefix"
+  :override_existing: true
+
+- :content_id: "fb2f116f-09d2-4861-99d7-b6ea8168fe5d"
+  :base_path: "/email/manage"
+  :title: "Email - manage"
+  :description: "Prefix route to allow email subscription management"
+  :rendering_app: "email-alert-frontend"
+  :type: "prefix"
+  :override_existing: true


### PR DESCRIPTION
It's considered tech debt that frontend apps publish their own routes. This adds email-alert-frontend's routes to special-route-publisher, and we will remove the publishing task from email-alert-frontend in [this PR](https://github.com/alphagov/email-alert-frontend/pull/1584)

https://trello.com/c/hJVUjqbs/31-frontend-apps-publish-content-items-to-publishing-api