### PR TITLE
Add task to publish all routes for a particular app

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,30 @@ To publish all routes:
 env PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_special_routes
 ```
 
+To publish all routes for one application:
+
+```
+env PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_one_route[email-alert-frontend]
+```
+
 To publish one route:
 
 ```
-env PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_one_route["/base-path"]
+env PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake publish_one_route[/base-path]
 ```
+
+To unpublish one route so it will return Gone:
+
+```
+env PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake unpublish_one_route[/base-path]
+```
+
+To unpublish one route so it will return Redirect:
+
+```
+env PUBLISHING_API_BEARER_TOKEN=abc bundle exec rake unpublish_one_route[/base-path,/new-base-path]
+```
+
 
 ## Publishing routes on EKS
 
@@ -74,7 +93,7 @@ kubectl run -napps --image 172025368201.dkr.ecr.eu-west-1.amazonaws.com/special-
 Use the `[]` notation to pass parameters to a task, for example:
 
 ```
-kubectl run -napps --image 172025368201.dkr.ecr.eu-west-1.amazonaws.com/special-route-publisher ${USER/./-}-special-route-pub -- sh -c "GOVUK_APP_DOMAIN= PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS=1 PUBLISHING_API_BEARER_TOKEN=$token rake publish_one_special_route['/government/history/past-chancellors']"
+kubectl run -napps --image 172025368201.dkr.ecr.eu-west-1.amazonaws.com/special-route-publisher ${USER/./-}-special-route-pub -- sh -c "GOVUK_APP_DOMAIN= PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS=1 PUBLISHING_API_BEARER_TOKEN=$token rake publish_one_special_route[/government/history/past-chancellors]"
 ```
 
 Important: finally, delete your pod when it has finished running:

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,11 @@ task :publish_special_routes do
   SpecialRoutePublisher.publish_special_routes
 end
 
+desc "Publish all special routes for a single application to the Publishing API"
+task :publish_special_routes_for_app, [:app_name] do |_, args|
+  SpecialRoutePublisher.publish_special_routes_for_app(args.app_name)
+end
+
 desc "Publish a single special route to the Publishing API"
 task :publish_one_special_route, [:base_path] do |_, args|
   SpecialRoutePublisher.publish_one_route(args.base_path)

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -7,6 +7,16 @@ class SpecialRoutePublisher
     new.publish_routes(load_special_routes)
   end
 
+  def self.publish_special_routes_for_app(app_name)
+    routes = load_special_routes.filter { |r| r[:rendering_app] == app_name }
+
+    if routes.any?
+      new.publish_routes(routes)
+    else
+      puts "No routes for #{app_name} in /data/special_routes.yaml"
+    end
+  end
+
   def self.publish_one_route(base_path)
     route = load_special_routes.find { |r| r[:base_path] == base_path }
 
@@ -40,52 +50,56 @@ class SpecialRoutePublisher
     new.publish_routes(load_homepage)
   end
 
+  def publish_route(route, time)
+    type = route.fetch(:type, "exact")
+
+    logger.info("Publishing #{type} route #{route.fetch(:base_path)}, routing to #{route.fetch(:rendering_app)}...")
+
+    # Always request a path reservation before publishing the special route,
+    # with the flag to override any existing publishing app.
+    # This allows for routes that were previously published by other apps to
+    # be added to `special_routes.yaml` and "just work".
+    publishing_api.put_path(
+      route.fetch(:base_path),
+      publishing_app: "special-route-publisher",
+      override_existing: true,
+    )
+
+    publishing_api.put_content(
+      route.fetch(:content_id),
+      base_path: route.fetch(:base_path),
+      document_type: route.fetch(:document_type, "special_route"),
+      schema_name: route.fetch(:document_type, "special_route"),
+      title: route.fetch(:title),
+      description: route.fetch(:description, ""),
+      locale: "en",
+      details: {},
+      routes: [
+        {
+          path: route.fetch(:base_path),
+          type:,
+        },
+      ],
+      publishing_app: "special-route-publisher",
+      rendering_app: route.fetch(:rendering_app),
+      public_updated_at: time.now.iso8601,
+      update_type: route.fetch(:update_type, "major"),
+    )
+
+    if route[:links]
+      publishing_api.patch_links(
+        route.fetch(:content_id),
+        links: route[:links],
+      )
+    end
+
+    publishing_api.publish(route.fetch(:content_id))
+  end
+
   def publish_routes(routes)
     time = (Time.respond_to?(:zone) && Time.zone) || Time
     routes.each do |route|
-      type = route.fetch(:type, "exact")
-
-      logger.info("Publishing #{type} route #{route.fetch(:base_path)}, routing to #{route.fetch(:rendering_app)}...")
-
-      # Always request a path reservation before publishing the special route,
-      # with the flag to override any existing publishing app.
-      # This allows for routes that were previously published by other apps to
-      # be added to `special_routes.yaml` and "just work".
-      publishing_api.put_path(
-        route.fetch(:base_path),
-        publishing_app: "special-route-publisher",
-        override_existing: true,
-      )
-
-      publishing_api.put_content(
-        route.fetch(:content_id),
-        base_path: route.fetch(:base_path),
-        document_type: route.fetch(:document_type, "special_route"),
-        schema_name: route.fetch(:document_type, "special_route"),
-        title: route.fetch(:title),
-        description: route.fetch(:description, ""),
-        locale: "en",
-        details: {},
-        routes: [
-          {
-            path: route.fetch(:base_path),
-            type:,
-          },
-        ],
-        publishing_app: "special-route-publisher",
-        rendering_app: route.fetch(:rendering_app),
-        public_updated_at: time.now.iso8601,
-        update_type: route.fetch(:update_type, "major"),
-      )
-
-      if route[:links]
-        publishing_api.patch_links(
-          route.fetch(:content_id),
-          links: route[:links],
-        )
-      end
-
-      publishing_api.publish(route.fetch(:content_id))
+      publish_route(route, time)
     rescue KeyError => e
       logger.error("Unable to publish #{route} due to an error: #{e}")
     end

--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -175,6 +175,14 @@ RSpec.describe SpecialRoutePublisher, "#publish_special_routes" do
       end
     end
 
+    context "publishing for one app" do
+      it "only publishes all routes for that app" do
+        expect_any_instance_of(described_class).to receive(:publish_route).exactly(6).times.with(hash_including(rendering_app: "email-alert-frontend"), anything)
+        expect_any_instance_of(described_class).not_to receive(:publish_route).with(hash_including(rendering_app: "content-store"), anything)
+        described_class.publish_special_routes_for_app("email-alert-frontend")
+      end
+    end
+
     context "hompage publishing" do
       it "publishes the homepage" do
         homepage_path = "/"


### PR DESCRIPTION
- If we're moving frontend apps published_api tasks into this app, we should make publishing all routes for one app into a single task, so that it's as close to calling the rake task on the old app as possible.
- Update readme to describe all the existing rake tasks under the Running locally heading (the first time in the doc the rake tasks are mentioned).
- Refactor SpecialRoutePublisher.publish_routes method (tiny decrease in a giant method size, improved testability)

Adds `publish_special_routes_for_app[app-name]` rake task

https://trello.com/c/hJVUjqbs/31-frontend-apps-publish-content-items-to-publishing-api