### PR TITLE
Make use of govuk-dependabot-merger v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# simplecov
+coverage/

--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,0 +1,7 @@
+api_version: 2
+defaults:
+  allowed_semver_bumps:
+    - patch
+    - minor
+  auto_merge: true
+  update_external_dependencies: true

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec"
   gem "rubocop-govuk"
+  gem "simplecov", require: false
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
       bigdecimal
       rexml
     diff-lcs (1.5.1)
+    docile (1.4.0)
     domain_name (0.6.20240107)
     drb (2.2.1)
     gds-api-adapters (95.1.0)
@@ -124,6 +125,12 @@ GEM
     rubocop-rspec_rails (2.28.2)
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -143,6 +150,7 @@ DEPENDENCIES
   rake
   rspec
   rubocop-govuk
+  simplecov
   webmock
 
 BUNDLED WITH

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "simplecov"
+SimpleCov.start
 require "webmock/rspec"
 
 RSpec.configure do |config|


### PR DESCRIPTION
As per RFC 167's [Conditions required for automatic patching](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#conditions-required-for-automatic-patching), this repo has:

- Sufficient test coverage ✅
- Sufficient security scanning ✅
- No manual deployment step ✅
- Branch protection rules in place ✅
- Been configured to only merge patch/minor updates ✅

Trello: https://trello.com/c/0FUL9Cv7/2541-upgrade-our-publishing-apps-to-govuk-dependabot-merger-v2